### PR TITLE
Improving usability

### DIFF
--- a/src/components/Results/index.tsx
+++ b/src/components/Results/index.tsx
@@ -7,9 +7,14 @@ type ResultsProps = {
 };
 
 export const Results = ({ searchParams }: ResultsProps) => {
-  const { data, error, isLoading } = useNasaQuery(searchParams);
+  const { data, error, isFetching } = useNasaQuery(searchParams);
 
-  return <Text>Results goes here</Text>;
+  return (
+    <>
+      <Text>results go here</Text>
+      <Text>{JSON.stringify(data)}</Text>;
+    </>
+  );
 };
 
 export default Results;

--- a/src/hooks/useNasaQuery.ts
+++ b/src/hooks/useNasaQuery.ts
@@ -3,11 +3,14 @@ import { useQuery } from "@tanstack/react-query";
 import urlNasaSearch from "../services/nasa";
 import { NasaResponse, NasaSearchParams } from "../types";
 
-export const useNasaQuery = (params: NasaSearchParams) => {
-  const urlNasaSearchUrl = urlNasaSearch(params);
+export const useNasaQuery = (params: NasaSearchParams | undefined) => {
+  const urlNasaSearchUrl = params ? urlNasaSearch(params) : "";
 
-  return useQuery<NasaResponse>(["nasaSearch"], () =>
-    fetch(urlNasaSearchUrl).then((res) => res.json())
+  // if params is empty then no request happens
+  return useQuery<NasaResponse>(
+    ["nasaSearch"],
+    () => fetch(urlNasaSearchUrl).then((res) => res.json()),
+    { enabled: !!params }
   );
 };
 

--- a/src/services/nasa.ts
+++ b/src/services/nasa.ts
@@ -10,7 +10,8 @@ export const urlNasaSearch = ({
   const paramsObjectWithSnakeCaseKeys = {
     keywords,
     media_type: mediaType,
-    year_start: `${yearStart ?? ""}`,
+    ...(!!yearStart &&
+      !Number.isNaN(yearStart) && { year_start: `${yearStart}` }),
   };
   const paramsString = new URLSearchParams(
     paramsObjectWithSnakeCaseKeys


### PR DESCRIPTION
allowing startYear to be missing in the query string as specified in the readme, allowing undefined to be passed to react query as a no op. Help the user by indicating that isFetching is probably more useful than isLoading